### PR TITLE
Add env variable to control the AWS Region

### DIFF
--- a/hackathon2022/settings.py
+++ b/hackathon2022/settings.py
@@ -32,6 +32,7 @@ try:
     AWS_ACCESS_KEY = os.environ["AWS_ACCESS_KEY"]
     AWS_SECRET_KEY = os.environ["AWS_SECRET_KEY"]
     AWS_S3_BUCKET = os.environ["AWS_S3_BUCKET"]
+    AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
 except KeyError:
     print("Error: Must set the following environment variables:\n\tAWS_ACCESS_KEY\n\tAWS_SECRET_KEY\n\tAWS_S3_BUCKET")
     sys.exit()

--- a/offensiveAdsFlagger/views.py
+++ b/offensiveAdsFlagger/views.py
@@ -40,12 +40,14 @@ transcribe_client = boto3.client(
     "transcribe",
     aws_access_key_id=settings.AWS_ACCESS_KEY,
     aws_secret_access_key=settings.AWS_SECRET_KEY,
+    region_name=settings.AWS_REGION,
 )
 
 s3_client = boto3.client(
     "s3",
     aws_access_key_id=settings.AWS_ACCESS_KEY,
     aws_secret_access_key=settings.AWS_SECRET_KEY,
+    region_name=settings.AWS_REGION,
 )
 
 


### PR DESCRIPTION
Some users might not have the region set by default, so we'll let them
set it via an env variable or default to `us-east-1`.